### PR TITLE
terminology cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Check gpg signatures in an automated way, for example in scripts.
+Check OpenPGP signatures in an automated way, for example in scripts.
 
 # Motivation
 

--- a/gpgverify
+++ b/gpgverify
@@ -59,7 +59,7 @@ class Signature:
     def __init__(self):
         self.good = False
         self.fingerprint = None
-        self.trusted = False
+        self.key_validity = False
 
 def evaluate_result(args, status_output):
     lines = status_output.decode().split("\n")
@@ -75,10 +75,10 @@ def evaluate_result(args, status_output):
         elif status[0] == "VALIDSIG" and len(signatures) > 0 and len(status) >= 11:
             signatures[-1].fingerprint = status[10]
         elif status[0] in ("TRUST_FULLY", "TRUST_ULTIMATE") and len(signatures) > 0:
-            signatures[-1].trusted = True
+            signatures[-1].key_validity = True
     found_accepted_sig = False
     for signature in signatures:
-        if signature.good and signature.trusted and \
+        if signature.good and signature.key_validity and \
                 signature.fingerprint is not None and \
                 signature.fingerprint == args.fp:
             found_accepted_sig = True


### PR DESCRIPTION
Here are a few patches that change no functionality, but make the semantics of gpgverify a bit clearer.

Users of `gpgverify` might also be interested in [the stateless OpenPGP interface](https://datatracker.ietf.org/doc/draft-dkg-openpgp-stateless-cli/) which is less interested in what happens to be in the user's GnuPG keyring, and is probably better suited to robust programmatic use.